### PR TITLE
Add new dependency and alt build to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Binaries will be found in `/builder/build/release/bin/`
 ##### Alternative Linux Build
 -`git clone --recursive https://github.com/CalexCore/AmityCoinV3.git`  
 -`cd AmityCoinV3`
-- `mkdir build && cd $_ && cmake -DCMAKE_BUILD_TYPE=release -DSTATIC=${STATIC} -DBUILD_TAG="linux_x64" .. && make`
+-`mkdir build && cd $_ && cmake -DCMAKE_BUILD_TYPE=release -DSTATIC=${STATIC} -DBUILD_TAG="linux_x64" .. && make`
 
-Binaries will be found in `/build/src/`
+Binaries will be found in `/build/bin/`

--- a/README.md
+++ b/README.md
@@ -22,12 +22,20 @@ See [LICENSE](LICENSE).
 #### Linux
 
 ##### One Liner for all Dependencies (Ubuntu/Debian):   
-`sudo apt-get install git curl ca-certificates nano zip unzip tar xz-utils cmake g++ make pkg-config libtool-bin autoconf automake build-essential cmake pkg-config pcsc-tools pcscd libpcsclite1 python-dev virtualenv libudev-dev libhidapi-dev libzmq3-dev libunbound-dev libboost-all-dev libusb-1.0-0-dev libusb-dev libssl-dev libsodium-dev libcurl4-openssl-dev libminiupnpc-dev libunwind8-dev liblzma-dev libreadline6-dev libldns-dev libexpat1-dev libgtest-dev doxygen graphviz libhidapi-libusb0`  
+`sudo apt-get install git curl ca-certificates nano zip unzip tar xz-utils cmake g++ make pkg-config libtool-bin autoconf automake build-essential cmake pkg-config pcsc-tools pcscd libpcsclite1 python-dev virtualenv libudev-dev libhidapi-dev libzmq3-dev libunbound-dev libboost-all-dev libusb-1.0-0-dev libusb-dev libssl-dev libsodium-dev libcurl4-openssl-dev libminiupnpc-dev libunwind8-dev liblzma-dev libreadline6-dev libldns-dev libexpat1-dev libgtest-dev doxygen graphviz libhidapi-libusb0 libzmq3-dev`  
   
  ##### Build Commands
 
+##### Linux Ubuntu & Fedora
 -`git clone --recursive https://github.com/CalexCore/AmityCoinV3.git`  
 -`cd AmityCoinV3`  
 -`./builder/linux`
-  
+
 Binaries will be found in `/builder/build/release/bin/`
+
+##### Alternative Linux Build
+-`git clone --recursive https://github.com/CalexCore/AmityCoinV3.git`  
+-`cd AmityCoinV3`
+- `mkdir build && cd $_ && cmake -DCMAKE_BUILD_TYPE=release -DSTATIC=${STATIC} -DBUILD_TAG="linux_x64" .. && make`
+
+Binaries will be found in `/build/src/`


### PR DESCRIPTION
- add ØMQ core (libzmq) 4.2 as a needed dependency
- add alt build